### PR TITLE
chore: .gitignore追加とREADME更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /app/*/.phpunit.cache/
 /app/*/.phpunit.result.cache
 /.worktree-*/
+package-lock.json
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Kent Beck著「テスト駆動開発（Test-Driven Development）」をPHP 8.5�
 - Slash Command
 - skills
 - sub agent
+- git worktree + sub agentsによる並列開発
 - hook
 - MCP
 - claude.md / rules


### PR DESCRIPTION
## 概要

リポジトリの衛生管理として、不要ファイルの.gitignore追加とREADMEの習得機能リスト更新を行う。

## 変更内容

- `.gitignore` に `package-lock.json` を追加（MCP serverのnpxで生成される不要ファイル）
- `.gitignore` に `.claude/settings.local.json` を追加（ローカル固有の権限設定）
- READMEの「習得したいClaude Code機能」に「git worktree + sub agentsによる並列開発」を追加

## PHPレビュー

PHPコードの変更なし。該当なし。

## 関連Issue

- #42

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>