### PR TITLE
feat(money): 第16章 抽象化、ついに

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -5,8 +5,8 @@ TDD本のToDoリストを管理するファイル。
 ## TODO
 
 - [x] $5 + 10 CHF = $10（レートが2:1の場合）
-- [ ] Sum.plus
-- [ ] Sum.times
+- [x] Sum.plus
+- [x] Sum.times
 - [x] $5 + $5 = $10
 - [x] $5 × 2 = $10
 - [x] amountをprivateにする

--- a/app/money/src/Expression.php
+++ b/app/money/src/Expression.php
@@ -8,4 +8,5 @@ interface Expression
 {
     public function reduce(Bank $bank, string $to): Money;
     public function plus(Expression $addend): Expression;
+    public function times(int $multiplier): Expression;
 }

--- a/app/money/src/Expression.php
+++ b/app/money/src/Expression.php
@@ -7,4 +7,5 @@ namespace Money;
 interface Expression
 {
     public function reduce(Bank $bank, string $to): Money;
+    public function plus(Expression $addend): Expression;
 }

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -20,7 +20,7 @@ class Money implements Expression
         return $this->currency;
     }
 
-    public function times(int $multiplier): Money
+    public function times(int $multiplier): Expression
     {
         return new Money($this->amount * $multiplier, $this->currency);
     }

--- a/app/money/src/Sum.php
+++ b/app/money/src/Sum.php
@@ -20,4 +20,9 @@ class Sum implements Expression
         $amount = $this->augend->reduce($bank, $to)->amount + $this->addend->reduce($bank, $to)->amount;
         return new Money($amount, $to);
     }
+
+    public function plus(Expression $addend): Expression
+    {
+        return new Sum($this, $addend);
+    }
 }

--- a/app/money/src/Sum.php
+++ b/app/money/src/Sum.php
@@ -25,4 +25,9 @@ class Sum implements Expression
     {
         return new Sum($this, $addend);
     }
+
+    public function times(int $multiplier): Expression
+    {
+        return new Sum($this->augend->times($multiplier), $this->addend->times($multiplier));
+    }
 }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -89,4 +89,15 @@ class MoneyTest extends TestCase
         $result = $bank->reduce($sum->plus($fiveBucks), 'USD');
         $this->assertTrue(Money::dollar(15)->equals($result));
     }
+
+    public function testSumTimes(): void
+    {
+        $fiveBucks = Money::dollar(5);
+        $tenFrancs = Money::franc(10);
+        $bank = new Bank();
+        $bank->addRate('CHF', 'USD', 2);
+        $sum = new Sum($fiveBucks, $tenFrancs);
+        $result = $bank->reduce($sum->times(2), 'USD');
+        $this->assertTrue(Money::dollar(20)->equals($result));
+    }
 }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -78,4 +78,15 @@ class MoneyTest extends TestCase
         $result = $bank->reduce($fiveBucks->plus($tenFrancs), 'USD');
         $this->assertTrue(Money::dollar(10)->equals($result));
     }
+
+    public function testSumPlusMoney(): void
+    {
+        $fiveBucks = Money::dollar(5);
+        $tenFrancs = Money::franc(10);
+        $bank = new Bank();
+        $bank->addRate('CHF', 'USD', 2);
+        $sum = new Sum($fiveBucks, $tenFrancs);
+        $result = $bank->reduce($sum->plus($fiveBucks), 'USD');
+        $this->assertTrue(Money::dollar(15)->equals($result));
+    }
 }


### PR DESCRIPTION
## 概要

Expression抽象を完成させた。SumクラスにもMoneyと同じ`plus()`と`times()`を実装し、Expressionインターフェースを統一した。

## 変更内容

- `Expression`インターフェースに`plus()`と`times()`を追加
- `Sum`クラスに`plus()`と`times()`を実装
- `Money.times()`の戻り値型を`Money`から`Expression`に変更
- `testSumPlusMoney()`と`testSumTimes()`テストを追加
- TODO.mdのSum.plusとSum.timesをチェック

## 関連Issue

- #60

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Expressions can now be added together and multiplied by integers for flexible composition and scaling of financial calculations.

* **Tests**
  - Added tests validating addition and multiplication operations on expressions with proper handling of currency conversion and exchange rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->